### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/dao/AbstractBaseDao.js
+++ b/lib/dao/AbstractBaseDao.js
@@ -7,7 +7,7 @@
  * @created: 9/2/14
  */
 const dash = require('lodash'),
-    uuid = require('node-uuid');
+    uuid = require('uuid');
 
 const AbstractBaseDao = function(options) {
     'use strict';

--- a/lib/services/AbstractPageService.js
+++ b/lib/services/AbstractPageService.js
@@ -5,7 +5,7 @@
  * @created 2016-09-22
  */
 const dash = require('lodash'),
-    uuid = require('node-uuid'),
+    uuid = require('uuid'),
     fs = require('fs');
 
 const AbstractPageService = function(options) {

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "datetimejs": "^0.3.4",
     "express-mocks-http": "0.0.11",
     "lodash": "^4.16.2",
-    "node-uuid": "^1.4.7",
     "simple-node-logger": "^0.93.12",
     "superagent": "^2.3.0",
+    "uuid": "^3.0.0",
     "validator": "^6.0.0"
   },
   "devDependencies": {

--- a/test/fixtures/TestDataset.js
+++ b/test/fixtures/TestDataset.js
@@ -5,7 +5,7 @@
  * @created: 8/11/14 10:36 AM
  */
 const dash = require("lodash" ),
-    uuid = require('node-uuid'),
+    uuid = require('uuid'),
     AbstractBaseModel = require('../../lib/models/AbstractBaseModel');
 
 const TestDataset = function() {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.